### PR TITLE
Fix instance segmentation

### DIFF
--- a/renderer/model/obj.cc
+++ b/renderer/model/obj.cc
@@ -161,14 +161,35 @@ void ObjLoader::sort_by_transparent(const TextureRegistry& tex) {
      return tex.is_transparent(m.diffuse_texname);
   };
 
-  std::sort(shapes.begin(), shapes.end(),
-      [this, &is_transparent_material](const tinyobj::shape_t& a, const tinyobj::shape_t& b) -> bool {
+  std::vector<size_t> indices;
+  indices.reserve(shapes.size());
+  for (size_t i = 0; i < shapes.size(); i++) {
+    indices.push_back(i);
+  }
+
+  // Get the sorted indices for the shapes
+  std::sort(indices.begin(), indices.end(),
+      [this, &is_transparent_material](const size_t& a_idx, const size_t& b_idx) -> bool {
+        const tinyobj::shape_t& a = this->shapes[a_idx];
+        const tinyobj::shape_t& b = this->shapes[b_idx];
         bool is_a = is_transparent_material(a.mesh.material_ids[0]),
              is_b = is_transparent_material(b.mesh.material_ids[0]);
         if (is_a != is_b)
           return is_b;
         return a.name.compare(b.name) < 0;
-      });
+  });
+
+  // Sort both shapes and shape_ids
+  std::vector<tinyobj::shape_t> sorted_shapes;
+  std::vector<int> sorted_shape_ids;
+  sorted_shapes.reserve(shapes.size());
+  shape_ids.reserve(shape_ids.size());
+  for (const size_t idx : indices) {
+    sorted_shapes.push_back(shapes[idx]);
+    sorted_shape_ids.push_back(shape_ids[idx]);
+  }
+  std::swap(shapes, sorted_shapes);
+  std::swap(shape_ids, sorted_shape_ids);
 }
 
 TextureRegistry::TextureRegistry(

--- a/renderer/suncg/category.hh
+++ b/renderer/suncg/category.hh
@@ -27,26 +27,30 @@ class ModelCategory final {
     // remove the shapes matching coarse grained categories
     void filter_category(
         std::vector<tinyobj::shape_t>& shapes,
+        std::vector<int>& shape_ids,
         const std::unordered_set<std::string>& categories) {
-      shapes.erase(
-          std::remove_if(shapes.begin(),
-            shapes.end(),
-            // remove person from the scene
-            [&](const tinyobj::shape_t& shape) {
-              std::string name = shape.name;
-              static std::string prefix = "Model#";
-              if (name.substr(0, prefix.size()) != prefix)
-                return false;
-              name = name.substr(prefix.size());
-              auto itr = coarse_grained_class_.find(name);
-              if (itr != coarse_grained_class_.end())
-                if (categories.count(itr->second)) {
-                  print_debug("Removing %s of class %s\n", shape.name.c_str(), itr->second.c_str());
-                  return true;
-                }
-            return false;
-            }), shapes.end()
-          );
+
+      std::vector<tinyobj::shape_t> filtered_shapes;
+      std::vector<int> filtered_shape_ids;
+      for (size_t i = 0; i < shapes.size(); i++) {
+        auto& shape = shapes[i];
+        std::string name = shape.name;
+        static std::string prefix = "Model#";
+        if (name.substr(0, prefix.size()) == prefix) {
+          name = name.substr(prefix.size());
+          auto itr = coarse_grained_class_.find(name);
+          if (itr != coarse_grained_class_.end() && categories.count(itr->second)) {
+              print_debug("Removing %s of class %s\n", shape.name.c_str(), itr->second.c_str());
+              continue;
+          }
+        }
+
+        filtered_shapes.push_back(shape);
+        filtered_shape_ids.push_back(shape_ids[i]);
+      }
+
+      std::swap(shapes, filtered_shapes);
+      std::swap(shape_ids, filtered_shape_ids);
     }
 
     std::string get_coarse_grained_class(std::string model_id) {

--- a/renderer/suncg/scene.cc
+++ b/renderer/suncg/scene.cc
@@ -128,7 +128,7 @@ SUNCGScene::SUNCGScene(string obj_file, string model_category_file,
       set_object_name_resolution_mode(ObjectNameResolution::FINE);
 
     // filter out person
-    model_category_.filter_category(obj_.shapes, {"person"});
+    model_category_.filter_category(obj_.shapes, obj_.shape_ids, {"person"});
     // split shapes
     obj_.split_shapes_by_material();
     obj_.printInfo();


### PR DESCRIPTION
The shape IDs and shapes were getting out of sync from the transparency sorting (we overlooked that before), so this just sorts the shape IDs along with the shapes to fix.

RGB of scene for reference:
![02a77d4ac6b938ce05e66b5b7508acb1_mode0](https://user-images.githubusercontent.com/23423584/34802772-3a9c71d6-f624-11e7-9da1-3752b4ccd952.png)

Instance segmentation before the fix:
![02a77d4ac6b938ce05e66b5b7508acb1_mode2](https://user-images.githubusercontent.com/23423584/34802774-3ad70436-f624-11e7-878a-d6434b4a9280.png)

Instance segmentation after the fix (note location is slightly different but you can see the trees are properly segmented):
![02a77d4ac6b938ce05e66b5b7508acb1_mode2_fixed](https://user-images.githubusercontent.com/23423584/34802773-3abbb0aa-f624-11e7-9dc0-8da6ca160667.png)
