### PR TITLE
Inverse depth

### DIFF
--- a/House3D/common.py
+++ b/House3D/common.py
@@ -3,16 +3,18 @@
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+
 import json
 import os
-from .house import House
+
 
 def load_config(filename):
     """
     Returns:
         dict
     """
-    config = json.load(open(filename, 'r'))
+    with open(filename) as file:
+        config = json.load(file)
 
     # back-compat
     if 'csvFile' in config:
@@ -22,9 +24,13 @@ def load_config(filename):
     required_files = ["prefix", "modelCategoryFile", "colorFile"]
     for f in required_files:
         assert f in config, 'Invalid config! key <{}> is missing!'.format(f)
-        assert os.path.exists(config[f]), 'Invalid config! path <{}> not exists!'.format(config[f])
+        assert os.path.exists(
+            config[f]), 'Invalid config! path <{}> not exists!'.format(
+                config[f])
         if ('File' in f):
-            assert os.path.isfile(config[f]), 'Invalid config! <{}> is not a valid file!'.format(config[f])
+            assert os.path.isfile(
+                config[f]), 'Invalid config! <{}> is not a valid file!'.format(
+                    config[f])
 
     return config
 
@@ -35,12 +41,14 @@ def create_default_config(prefix, colormap='coarse'):
 
     metadir = os.path.join(os.path.dirname(__file__), 'metadata')
     ret = {
-        'colorFile': os.path.join(
-            metadir,
-            'colormap_coarse.csv' if colormap == 'coarse' else 'colormap_fine.csv'),
-        'roomTargetFile': os.path.join(metadir, 'room_target_object_map.csv'),
-        'modelCategoryFile': os.path.join(metadir, 'ModelCategoryMapping.csv'),
-        'prefix': prefix
+        'colorFile':
+        os.path.join(metadir, 'colormap_coarse.csv'
+                     if colormap == 'coarse' else 'colormap_fine.csv'),
+        'roomTargetFile':
+        os.path.join(metadir, 'room_target_object_map.csv'),
+        'modelCategoryFile':
+        os.path.join(metadir, 'ModelCategoryMapping.csv'),
+        'prefix':
+        prefix
     }
     return ret
-

--- a/House3D/core.py
+++ b/House3D/core.py
@@ -80,14 +80,16 @@ class Environment():
     def set_render_mode(self, mode):
         """
         Args:
-            mode (str or enum): one of 'rgb', 'depth', 'semantic',
-                RenderMode.RGB, RenderMode.DEPTH, RenderMode.SEMANTIC
+            mode (str or enum): either a RenderMode value or its string version.
+                                'rgb', 'depth', 'semantic', 'instance', or 'invdepth'
         """
         mappings = {
-                'rgb': RenderMode.RGB,
-                'depth': RenderMode.DEPTH,
-                'semantic': RenderMode.SEMANTIC,
-                'instance': RenderMode.INSTANCE }
+            'rgb': RenderMode.RGB,
+            'depth': RenderMode.DEPTH,
+            'semantic': RenderMode.SEMANTIC,
+            'instance': RenderMode.INSTANCE,
+            'invdepth': RenderMode.INVDEPTH,
+        }
         if isinstance(mode, six.string_types):
             mode = mode.lower()
             self.api_mode = mappings[mode]

--- a/renderer/python/pybind.cc
+++ b/renderer/python/pybind.cc
@@ -73,6 +73,7 @@ PYBIND11_MODULE(objrender, m) {
     .value("SEMANTIC", SUNCGScene::RenderMode::SEMANTIC)
     .value("DEPTH", SUNCGScene::RenderMode::DEPTH)
     .value("INSTANCE", SUNCGScene::RenderMode::INSTANCE)
+    .value("INVDEPTH", SUNCGScene::RenderMode::INVDEPTH)
     .export_values();
 
   py::enum_<Camera::Movement>(camera, "Movement")

--- a/renderer/suncg/render.hh
+++ b/renderer/suncg/render.hh
@@ -47,20 +47,35 @@ class SUNCGRenderAPI {
 
     void setMode(SUNCGScene::RenderMode m) { scene_->set_mode(m); }
 
-    // Render the image. The return format is:
-    // For RGB mode, returns a 3-channel RGB image.
-    // For semantic mode, returns a 3-channel image. The mapping from color to class is in the CSV.
-    // For instance mode, returns a 3-channel image.
-    //  Each unique color means an instance and the coloring is consistent across different views.
+    // Render the image. The return format depends on the rendering mode, which
+    // is set with the method above:
     //
-    // For depth mode, returns a 2-channel image.
+    // For RGB mode, returns a 3-channel RGB image of the rendered scene.
     //
-    // The first channel contains depth values scaled to (0, 255),
-    // where pixel / 255.0 * 20.0 is the true depth in meters.
-    // Any pixels that are further than 20 meters away will be clipped to 20 meters.
+    // For SEMANTIC mode, returns a 3-channel image.
+    //  The mapping from color to class is in the CSV.
     //
-    // The second channel is an "infinity" mask. Each value is either 0 or 255.
-    // 255 means this pixel is at infinty depth, and the correspoding first channel is meaningless.
+    // For INSTANCE mode, returns a 3-channel image.
+    //  Each unique color means an instance and the coloring is consistent
+    //  across different views.
+    //
+    // For DEPTH mode, returns a 2-channel image:
+    //  The first channel contains depth values scaled to (0, 255), where
+    //  pixel / 255.0 * 20.0 is the true depth in meters. Any pixels that are
+    //  further than 20 meters away will be clipped to 20 meters.
+    //  The second channel is an "infinity" mask. Each value is either 0 or 255.
+    //  255 means this pixel is at infinty depth, and the correspoding first
+    //  channel is meaningless.
+    //
+    // INVDEPTH mode also returns a 2-channel image, of 16-bit inverse depth.
+    //  It can be converted to a single uint16 inverse depth image as follows:
+    //    img16 = img.astype(np.uint16)
+    //    inverse_depth_16 = img16[:, :, 0] * 256 + img16[:, :, 1]
+    //  To convert from inverse depth to float depth, you can use:
+    //    PIXEL_MAX = np.iinfo(np.uint16).max
+    //    NEAR = 0.3 # has to match minDepth parameter
+    //    depth = NEAR * PIXEL_MAX / inverse_depth_16.astype(np.float)
+    //
     Matuc render();
 
     // Render a cube map of size 6w * h * c.  See render() for rendering details.
@@ -151,4 +166,3 @@ class SUNCGRenderAPIThread {
 };
 
 }
-

--- a/renderer/suncg/scene.cc
+++ b/renderer/suncg/scene.cc
@@ -10,6 +10,8 @@
 
 #include "category.hh"
 
+#include <stdexcept>
+
 using namespace std;
 
 namespace {
@@ -58,25 +60,42 @@ uniform float dissolve;
 uniform sampler2D texture_diffuse;
 
 // TODO change NEAR to 0.01
-float near = 0.1;
-float far  = 100.0;
-float DEPTH_SCALE = 20.0;
+// Note these values need to match DEFAULT_NEAR and DEFAULT_FAR in camera.h
+const float NEAR = 0.1f;
+const float FAR  = 100.0f;
+const float INV_NEAR = 1.0f/NEAR;
+const float INV_FAR  = 1.0f/FAR;
+const float DEPTH_SCALE = 20.0f;
 
-// convert depth buffer value to true depth
-// https://learnopengl.com/#!Advanced-OpenGL/Depth-testing
-float LinearizeDepth(float depth) {
-    float z = depth * 2.0 - 1.0; // back to NDC
-    return (2.0 * near * far) / (far + near - z * (far - near));
+// Convert depth buffer value to inverse depth.
+// The depth buffer value <d> is 0.0 for INV_NEAR, 1.0 for INV_FAR.
+float InverseDepth(float d) {
+    return INV_NEAR + d * (INV_FAR - INV_NEAR);
+}
+
+// Convert depth buffer value to true depth.
+float TrueDepth(float d) {
+    return 1.0f / InverseDepth(d);
 }
 
 void main() {
     if (mode == 2u) { // constant
-      fragcolor = vec4(Kd, 1.f);
+      fragcolor = vec4(Kd, 1.0f);
       return;
     }
-    if (mode == 3u) { // depth
-      float depth = LinearizeDepth(gl_FragCoord.z) / DEPTH_SCALE;
-      fragcolor = vec4(vec3(depth), 1.0);
+    else if (mode == 3u) { // depth
+      float scaledDepth = TrueDepth(gl_FragCoord.z) / DEPTH_SCALE;
+      fragcolor = vec4(vec3(scaledDepth), 1.0f);
+      return;
+    }
+    else if (mode == 4u) { // inverse depth
+      float invDepth = InverseDepth(gl_FragCoord.z);
+      // invDepth \in [INV_FAR, INV_NEAR] i.e., [0.01, 10.0] with above values.
+      // We convert to 16 bits, with 65535 corresponding to INV_NEAR
+      float f = 65535 * invDepth * NEAR + 0.5; // \in [0.0, 65535.0]
+      float ms = floor(f/256.0f); // \in {0.0, .., 255.0}
+      float ls = floor(f - ms * 256.0f); // \in {0.0, .., 255.0}
+      fragcolor = vec4(ms/255.0f, ls/255.0f, 0.0f, 1.0f);
       return;
     }
 
@@ -96,9 +115,9 @@ void main() {
     vec3 in_vec = normalize(eye - pos);
     // have some diffuse color even when orthogonal
     float scale = max(dot(in_vec, normal), 0.3f);
-    vec3 ambient = Ka * 0.1;
+    vec3 ambient = Ka * 0.1f;
     color = color * scale + ambient;
-    color = clamp(color, 0.f, 1.f);
+    color = clamp(color, 0.0f, 1.0f);
     fragcolor = vec4(color, alpha);
 }
 )xxx";
@@ -255,11 +274,18 @@ void SUNCGScene::draw() {
       glUniform1ui(shader_.mode_loc, static_cast<GLuint>(mode));
       mesh_[i].draw();
     }
-  } else {    // depth
+  } else if (mode_ == RenderMode::DEPTH) {
     auto mode = SUNCGShader::RenderMode::DEPTH;
     glUniform1ui(shader_.mode_loc, static_cast<GLuint>(mode));
     for (int i = 0; i < nr_mesh; ++i)
       mesh_[i].draw();
+  } else if (mode_ == RenderMode::INVDEPTH) {
+    auto mode = SUNCGShader::RenderMode::INVDEPTH;
+    glUniform1ui(shader_.mode_loc, static_cast<GLuint>(mode));
+    for (int i = 0; i < nr_mesh; ++i)
+      mesh_[i].draw();
+  } else {
+    throw runtime_error("unknown render mode");
   }
 }
 

--- a/renderer/suncg/scene.hh
+++ b/renderer/suncg/scene.hh
@@ -37,7 +37,8 @@ class SUNCGShader: public Shader {
       TEXTURE_LIGHTING = 0,
       LIGHTING = 1,
       CONSTANT = 2,
-      DEPTH = 3
+      DEPTH = 3,
+      INVDEPTH = 4
     };
 };
 
@@ -59,7 +60,8 @@ class SUNCGScene : public ObjSceneBase {
       RGB = 0,
       SEMANTIC = 1,
       DEPTH = 2,
-      INSTANCE = 3
+      INSTANCE = 3,
+      INVDEPTH = 4
     };
 
     enum class ObjectNameResolution {

--- a/renderer/suncg/scene.hh
+++ b/renderer/suncg/scene.hh
@@ -31,7 +31,7 @@ class SUNCGShader: public Shader {
 
     static const char* fShader;
     GLint Kd_loc, Ka_loc, mode_loc,
-          texture_loc, dissolve_loc;
+          texture_loc, dissolve_loc, minDepth_loc;
 
     enum class RenderMode : GLuint {
       TEXTURE_LIGHTING = 0,
@@ -47,7 +47,8 @@ class SUNCGScene : public ObjSceneBase {
     explicit SUNCGScene(
         std::string obj_file,
         std::string model_category_file,
-        std::string semantic_label_file);
+        std::string semantic_label_file,
+        float minDepth = 0.3);
     ~SUNCGScene() {}
 
     void draw() override;
@@ -99,7 +100,7 @@ class SUNCGScene : public ObjSceneBase {
     ColorMappingReader semantic_color_;
     glm::vec3 background_color_;
     std::vector<Mesh> mesh_;
-
+    float minDepth_; // used for inverse depth mode
 
     struct MaterialDesc {
       int id;  // material id in tinyobj

--- a/tests/test-samples.py
+++ b/tests/test-samples.py
@@ -12,7 +12,7 @@ import queue
 import time
 import argparse
 
-from House3D import objrender, Environment, MultiHouseEnv, load_config, House
+from House3D import objrender, Environment, load_config, House
 from House3D.objrender import RenderMode
 from threading import Thread, Lock
 
@@ -23,10 +23,17 @@ LOADING_THREADS = 10
 RENDER_THREADS = 1
 
 SAMPLES_PER_ROOM = 3
-ROOM_TYPES = set(['living_room'])
+ROOM_TYPES = {'living_room'}
 ROBOT_RAD = 1.0
-RENDER_MODES = [RenderMode.RGB, RenderMode.DEPTH, RenderMode.SEMANTIC, RenderMode.INSTANCE]
-RENDER_NAMES = ['rgb', 'depth', 'semantic', 'instance']
+RENDER_MODES = [
+    RenderMode.RGB,
+    RenderMode.DEPTH,
+    RenderMode.SEMANTIC,
+    RenderMode.INSTANCE,
+    RenderMode.INVDEPTH,
+]
+RENDER_NAMES = ['rgb', 'depth', 'semantic', 'instance', 'invdepth']
+
 
 class RestrictedHouse(House):
     def __init__(self, **kwargs):
@@ -45,15 +52,20 @@ def create_house(houseID, config, robotRadius=ROBOT_RAD):
     print('Loading house {}'.format(houseID))
     objFile = os.path.join(config['prefix'], houseID, 'house.obj')
     jsonFile = os.path.join(config['prefix'], houseID, 'house.json')
-    assert (os.path.isfile(objFile) and os.path.isfile(jsonFile)), '[Environment] house objects not found! objFile=<{}>'.format(objFile)
+    assert (
+        os.path.isfile(objFile) and os.path.isfile(jsonFile)
+    ), '[Environment] house objects not found! objFile=<{}>'.format(objFile)
     cachefile = os.path.join(config['prefix'], houseID, 'cachedmap1k.pkl')
     if not os.path.isfile(cachefile):
         cachefile = None
 
-    house = RestrictedHouse(JsonFile=jsonFile, ObjFile=objFile,
-                            MetaDataFile=config["modelCategoryFile"],
-                            CachedFile=cachefile, RobotRadius=robotRadius,
-                            SetTarget=False)
+    house = RestrictedHouse(
+        JsonFile=jsonFile,
+        ObjFile=objFile,
+        MetaDataFile=config["modelCategoryFile"],
+        CachedFile=cachefile,
+        RobotRadius=robotRadius,
+        SetTarget=False)
     return house
 
 
@@ -64,7 +76,6 @@ def get_house_dir(houseID):
 def gen_rand_house(cfg):
     all_house_ids = os.listdir(cfg['prefix'])
     np.random.shuffle(all_house_ids)
-    house = None
     for houseID in all_house_ids:
         house_dir = get_house_dir(houseID)
         if os.path.exists(house_dir):
@@ -95,12 +106,15 @@ def render_current_location(env, houseID, room_type, index):
         env.set_render_mode(RENDER_MODES[mode_idx])
         img = env.render_cube_map(copy=True)
         if render_mode == RenderMode.DEPTH:
-            img = img[:,:,0]
+            img = img[:, :, 0]
+        elif render_mode == RenderMode.INVDEPTH:
+            img16 = img.astype(np.uint16)
+            img = img16[:, :, 0] * 256 + img16[:, :, 0]
         else:
             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
         output_filename = '{}-room_{}-loc_{}-render_{}.png'.format(
-            houseID, room_type, index, RENDER_NAMES[mode_idx])
+            houseID, room_type, index, render_name)
         cv2.imwrite(os.path.join(output_dir, output_filename), img)
 
 
@@ -137,7 +151,8 @@ def house_loader(house_gen, cfg, house_queue, gen_lock):
             continue
 
         house_queue.put((houseID, house))
-        print('Put house {} in queue, total: {}'.format(houseID, house_queue.qsize()))
+        print('Put house {} in queue, total: {}'.format(houseID,
+                                                        house_queue.qsize()))
 
 
 def house_renderer(cfg, house_queue, progress_queue):
@@ -145,14 +160,14 @@ def house_renderer(cfg, house_queue, progress_queue):
         houseID, house = house_queue.get()
         api = objrender.RenderAPIThread(w=args.width, h=args.height, device=0)
         env = Environment(api, house, cfg)
-        cam = api.getCamera()
 
         loc_idx = 0
         valid_rooms = get_valid_rooms(house)
         for room in valid_rooms:
-            for i in range(SAMPLES_PER_ROOM):
+            for _i in range(SAMPLES_PER_ROOM):
                 if not reset_random(env, house, room):
-                    print('Unable to sample location for house {}'.format(houseID))
+                    print('Unable to sample location for house {}'.format(
+                        houseID))
                     break
                 render_current_location(env, houseID, room['id'], loc_idx)
                 loc_idx += 1
@@ -188,20 +203,22 @@ if __name__ == '__main__':
     progress_queue = queue.Queue()
 
     loader_threads = []
-    for i in range(LOADING_THREADS):
-        t = Thread(target=house_loader,
-                    args=(house_gen, cfg, house_queue, gen_lock))
+    for _i in range(LOADING_THREADS):
+        t = Thread(
+            target=house_loader, args=(house_gen, cfg, house_queue, gen_lock))
         t.start()
         loader_threads.append(t)
 
     render_threads = []
-    for i in range(RENDER_THREADS):
-        t = Thread(target=house_renderer, args=(cfg, house_queue, progress_queue))
+    for _i in range(RENDER_THREADS):
+        t = Thread(
+            target=house_renderer, args=(cfg, house_queue, progress_queue))
         t.daemon = True
         t.start()
         render_threads.append(t)
 
-    progress_thread = Thread(target=progress_tracker, args=(total, progress_queue))
+    progress_thread = Thread(
+        target=progress_tracker, args=(total, progress_queue))
     progress_thread.daemon = True
     progress_thread.start()
 

--- a/tests/test-samples.py
+++ b/tests/test-samples.py
@@ -109,7 +109,7 @@ def render_current_location(env, houseID, room_type, index):
             img = img[:, :, 0]
         elif render_mode == RenderMode.INVDEPTH:
             img16 = img.astype(np.uint16)
-            img = img16[:, :, 0] * 256 + img16[:, :, 0]
+            img = img16[:, :, 0] * 256 + img16[:, :, 1]
         else:
             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -14,7 +14,7 @@ from House3D.objrender import RenderMode
 PIXEL_MAX = np.iinfo(np.uint16).max
 ROOM_TYPE = 'kitchen'
 SIDE = 256
-NEAR = 0.1
+NEAR = 0.3
 
 
 def depth_of_inverse_depth(inverse_depth):
@@ -90,9 +90,9 @@ class TestCubeMap(unittest.TestCase):
         self.assertEqual(depth2.dtype, np.float)
         self.assertEqual(depth2.shape, (SIDE, SIDE * 6))
 
-        # Check that depth value is within 1% of depth from RenderMode.DEPTH
+        # Check that depth value is within 5% of depth from RenderMode.DEPTH
         self.assertAlmostEqual(
-            depth2[0, 0], depth_value, delta=depth_value * 0.01)
+            depth2[0, 0], depth_value, delta=depth_value * 0.05)
 
 
 if __name__ == '__main__':

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -1,0 +1,74 @@
+# Copyright 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+import os
+import unittest
+
+from House3D import objrender, Environment, load_config, House
+from House3D.objrender import RenderMode
+
+ROOM_TYPE = 'kitchen'
+SIDE = 256
+
+
+def create_house(houseID, config):
+    obj_file = os.path.join(config['prefix'], houseID, 'house.obj')
+    json_file = os.path.join(config['prefix'], houseID, 'house.json')
+    assert (
+        os.path.isfile(obj_file) and os.path.isfile(json_file)
+    ), '[Environment] house objects not found! obj_file=<{}>'.format(obj_file)
+    cache_file = os.path.join(config['prefix'], houseID, 'cachedmap1k.pkl')
+    if not os.path.isfile(cache_file):
+        cache_file = None
+    return House(
+        json_file,
+        obj_file,
+        config["modelCategoryFile"],
+        CachedFile=cache_file)
+
+
+def find_first_good_house(cfg):
+    house_ids = os.listdir(cfg['prefix'])
+    for house_id in house_ids:
+        house = create_house(house_id, cfg)
+        if house.hasRoomType(ROOM_TYPE):
+            return (house_id, house)
+
+
+class TestCubeMap(unittest.TestCase):
+    def test_render(self):
+        api = objrender.RenderAPI(w=SIDE, h=SIDE, device=0)
+        cfg = load_config('config.json')
+        houseID, house = find_first_good_house(cfg)
+        env = Environment(api, house, cfg)
+        location = house.getRandomLocation(ROOM_TYPE)
+        env.reset(*location)
+
+        # Check RGB
+        env.set_render_mode(RenderMode.RGB)
+        rgb = env.render_cube_map()
+        self.assertEqual(rgb.shape, (SIDE, SIDE * 6, 3))
+
+        # Check SEMANTIC
+        env.set_render_mode(RenderMode.RGB)
+        semantic = env.render_cube_map()
+        self.assertEqual(semantic.shape, (SIDE, SIDE * 6, 3))
+
+        # Check INSTANCE
+        env.set_render_mode(RenderMode.INSTANCE)
+        instance = env.render_cube_map()
+        self.assertEqual(instance.shape, (SIDE, SIDE * 6, 3))
+
+        # Check DEPTH
+        env.set_render_mode(RenderMode.DEPTH)
+        depth = env.render_cube_map()
+        self.assertEqual(depth.shape, (SIDE, SIDE * 6, 2))
+        self.assertEqual(depth.dtype, np.uint8)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -36,7 +36,8 @@ def create_house(houseID, config):
         json_file,
         obj_file,
         config["modelCategoryFile"],
-        CachedFile=cache_file)
+        CachedFile=cache_file,
+        SetTarget=False)
 
 
 def find_first_good_house(cfg):


### PR DESCRIPTION
I added a new render mode to the shader that renders 16-bit inverse depth, which provides more detail close to the camera. There are some formatting changes in response to linter complaining, as well, hopefully these don't distract from reviewing the core contribution which is in scene.cc. Most other changes are propagating the new mode to python, and adding rendering of inverse depth to test-samples.py. I also added a file unit-tests.py that checks one basic dimensions and well as numerical values of depth/inverse depth.

An example is here:

RGB:
![b814705bc93d428507a516b866efda28-room_0_15-loc_4-render_rgb](https://user-images.githubusercontent.com/10515273/38393500-d310466a-38df-11e8-8bba-6eeb576fc0ef.png)

depth:
![b814705bc93d428507a516b866efda28-room_0_15-loc_4-render_depth](https://user-images.githubusercontent.com/10515273/38393498-d2e23220-38df-11e8-96d6-9a59d04ec737.png)

inverse depth:
![b814705bc93d428507a516b866efda28-room_0_15-loc_4-render_invdepth](https://user-images.githubusercontent.com/10515273/38393499-d2f9bd64-38df-11e8-8759-2b8db766d9e3.png)

After fixing the bug found by @ppwwyyxx  in the test script, inverse depth looks even better:
![b814705bc93d428507a516b866efda28-room_0_15-loc_4-render_invdepth](https://user-images.githubusercontent.com/10515273/38399238-02399bb2-38fe-11e8-8432-57b2389d9701.png)